### PR TITLE
Fix Dockerfile with correct conda version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN wget -q -P /tmp \
 
 # Install conda packages.
 ENV PATH="/opt/conda/bin:$PATH"
-RUN conda update -qy conda \
+RUN conda install -qy conda==4.13.0 \
     && conda install -y -c conda-forge \
       openmm=7.5.1 \
       cudatoolkit==${CUDA_VERSION} \


### PR DESCRIPTION
Conda version is causing the docker build to fail.
Fixing conda image according to these bugs:

https://github.com/deepmind/alphafold/issues/573
https://github.com/deepmind/alphafold/issues/578

And this fix:
https://github.com/deepmind/alphafold/commit/dad1f286aeaa158702a98aeee0f5661f30de6da8

@jarokaz Could you please review?
Thank you!