### PR TITLE
add `wait_for_resource_creation` to notebook

### DIFF
--- a/1-alphafold-quick-start.ipynb
+++ b/1-alphafold-quick-start.ipynb
@@ -336,7 +336,8 @@
     "    labels=labels\n",
     ")\n",
     "\n",
-    "pipeline_job.run(sync=False)"
+    "pipeline_job.run(sync=False)\n",
+    "pipeline_job.wait_for_resource_creation()"
    ]
   },
   {


### PR DESCRIPTION
I added `wait_for_resource_creation` to the end of the notebook to wait for the resources to be created before getting the pipeline job status.