### PR TITLE
fixed pipeline image build and notebook runtime errors

### DIFF
--- a/1-alphafold-quick-start.ipynb
+++ b/1-alphafold-quick-start.ipynb
@@ -114,7 +114,7 @@
     "FILESTORE_SHARE = '/datasets'\n",
     "FILESTORE_MOUNT_PATH = '/mnt/nfs/alphafold'\n",
     "MODEL_PARAMS = f'gs://{BUCKET_NAME}'\n",
-    "IMAGE_URI = f'gcr.io/{PROJECT_ID}/alphafold-components'"
+    "IMAGE_URI = f'{REGION}-docker.pkg.dev/{PROJECT_ID}/alpha-kfp/alphafold-components'"
    ]
   },
   {

--- a/1.1-alphafold-quick-start-multimer.ipynb
+++ b/1.1-alphafold-quick-start-multimer.ipynb
@@ -114,7 +114,7 @@
     "FILESTORE_SHARE = '/datasets'\n",
     "FILESTORE_MOUNT_PATH = '/mnt/nfs/alphafold'\n",
     "MODEL_PARAMS = f'gs://{BUCKET_NAME}'\n",
-    "IMAGE_URI = f'gcr.io/{PROJECT_ID}/alphafold-components'"
+    "IMAGE_URI = f'{REGION}-docker.pkg.dev/{PROJECT_ID}/alpha-kfp/alphafold-components'"
    ]
   },
   {

--- a/Alphafold.dockerfile
+++ b/Alphafold.dockerfile
@@ -54,7 +54,7 @@ RUN wget -q -P /tmp \
 
 # Install conda packages.
 ENV PATH="/opt/conda/bin:$PATH"
-RUN conda install -qy conda==24.1.2 \
+RUN conda install -qy conda==24.1.2 conda-forge::libmamba \
     && conda install -y -c conda-forge \
       openmm=7.7.0 \
       pdbfixer \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ google-cloud-common==1.2.0
 google-cloud-notebooks==1.7.1
 shapely==1.8.5.post1
 pygeos==0.12.0
-geopandas
-google-cloud-aiplatform
+geopandas==0.14.4
+google-cloud-aiplatform==1.71.1
 google-cloud-pipeline-components==1.0.44
 biopython==1.81
 google-cloud-filestore==1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,10 @@ kfp-server-api==1.8.5
 kubernetes==25.3.0
 google-cloud-common==1.2.0
 google-cloud-notebooks==1.7.1
-google-cloud-aiplatform==1.28.1
+shapely==1.8.5.post1
+pygeos==0.12.0
+geopandas
+google-cloud-aiplatform
 google-cloud-pipeline-components==1.0.44
 biopython==1.81
 google-cloud-filestore==1.6.1

--- a/src/analysis/residue_constants.py
+++ b/src/analysis/residue_constants.py
@@ -772,10 +772,10 @@ def _make_rigid_transformation_4x4(ex, ey, translation):
 # and an array with (restype, atomtype, coord) for the atom positions
 # and compute affine transformation matrices (4,4) from one rigid group to the
 # previous group
-restype_atom37_to_rigid_group = np.zeros([21, 37], dtype=np.int)
+restype_atom37_to_rigid_group = np.zeros([21, 37], dtype=int)
 restype_atom37_mask = np.zeros([21, 37], dtype=np.float32)
 restype_atom37_rigid_group_positions = np.zeros([21, 37, 3], dtype=np.float32)
-restype_atom14_to_rigid_group = np.zeros([21, 14], dtype=np.int)
+restype_atom14_to_rigid_group = np.zeros([21, 14], dtype=int)
 restype_atom14_mask = np.zeros([21, 14], dtype=np.float32)
 restype_atom14_rigid_group_positions = np.zeros([21, 14, 3], dtype=np.float32)
 restype_rigid_group_default_frame = np.zeros([21, 8, 4, 4], dtype=np.float32)


### PR DESCRIPTION
Applied some small changes to fix pipeline image build and notebook runtime errors:

- image build: added libmamba to conda install.
- notebook: updated `requirements.txt` to include a more recent version of `google-cloud-aiplatform`.
- notebook: replaced `np.int` with `int`. `np.int` was deprecated in NumPy 1.20.0 and remove in 1.24.0. 
- notebook: update image uri from container registry to artifact registry format.