### PR TITLE
fix: variabilize artifact registry repo name

### DIFF
--- a/1-alphafold-quick-start.ipynb
+++ b/1-alphafold-quick-start.ipynb
@@ -80,7 +80,8 @@
     "PROJECT_ID = '<YOUR PROJECT ID>'  # Change to your project ID\n",
     "ZONE = '<YOUR ZONE>'   # Change to your zone (example: us-central1-c)\n",
     "BUCKET_NAME = '<YOUR BUCKET NAME>'  # Change to your bucket name\n",
-    "FILESTORE_ID = '<YOUR FILESTORE ID>' # Change to your Filestore ID"
+    "FILESTORE_ID = '<YOUR FILESTORE ID>' # Change to your Filestore ID\n",
+    "AR_REPO_NAME = '<YOUR ARTIFACT REGISTRY REPOSITORY NAME>' # Change to your Artifact Registry repository name"
    ]
   },
   {
@@ -114,7 +115,7 @@
     "FILESTORE_SHARE = '/datasets'\n",
     "FILESTORE_MOUNT_PATH = '/mnt/nfs/alphafold'\n",
     "MODEL_PARAMS = f'gs://{BUCKET_NAME}'\n",
-    "IMAGE_URI = f'{REGION}-docker.pkg.dev/{PROJECT_ID}/alpha-kfp/alphafold-components'"
+    "IMAGE_URI = f'{REGION}-docker.pkg.dev/{PROJECT_ID}/{AR_REPO_NAME}/alphafold-components'"
    ]
   },
   {


### PR DESCRIPTION
This PR variabilize the repo name so users can put their own repo instead of the hardcoded one